### PR TITLE
[MX-2568] Add support for config ADDITIONAL_CLIENTS_DIRECTORY

### DIFF
--- a/src/context/directory/handlers/clients.js
+++ b/src/context/directory/handlers/clients.js
@@ -6,10 +6,18 @@ import log from '../../../logger';
 import { isFile, getFiles, existsMustBeDir, loadJSON, sanitize, clearClientArrays } from '../../../utils';
 
 function parse(context) {
+  var foundFiles = [];
+
   const clientsFolder = path.join(context.filePath, constants.CLIENTS_DIRECTORY);
   if (!existsMustBeDir(clientsFolder)) return { clients: undefined }; // Skip
+  foundFiles = foundFiles.concat(getFiles(clientsFolder, [ '.json' ]));
 
-  const foundFiles = getFiles(clientsFolder, [ '.json' ]);
+  if (context.config.ADDITIONAL_CLIENTS_DIRECTORY) {
+    const additionalClientsFolder = path.join(context.filePath, context.config.ADDITIONAL_CLIENTS_DIRECTORY);
+    if (existsMustBeDir(additionalClientsFolder)) {
+      foundFiles = foundFiles.concat(getFiles(additionalClientsFolder, [ '.json' ]));
+    }
+  }
 
   const clients = foundFiles
     .map((f) => {

--- a/test/context/directory/clients.test.js
+++ b/test/context/directory/clients.test.js
@@ -36,6 +36,32 @@ describe('#directory context clients', () => {
     expect(context.assets.clients).to.deep.equal(target);
   });
 
+  it('should process additional clients directory', async () => {
+    const additionalClientsDirectory = 'additional-clients';
+
+    const files = {
+      [constants.CLIENTS_DIRECTORY]: {
+        'default-client.json': '{ "app_type": @@appType@@, "name": "defaultClient" }'
+      },
+      [additionalClientsDirectory]: {
+        'another-client.json': '{ "app_type": @@appType@@, "name": "anotherClient" }'
+      }
+    };
+
+    const repoDir = path.join(testDataDir, 'directory', 'clients1');
+    createDir(repoDir, files);
+
+    const config = { AUTH0_INPUT_FILE: repoDir, ADDITIONAL_CLIENTS_DIRECTORY: additionalClientsDirectory, AUTH0_KEYWORD_REPLACE_MAPPINGS: { appType: 'spa' } };
+    const context = new Context(config, mockMgmtClient());
+    await context.load();
+
+    const target = [
+      { app_type: 'spa', name: 'defaultClient' },
+      { app_type: 'spa', name: 'anotherClient' }
+    ];
+    expect(context.assets.clients).to.deep.equal(target);
+  });
+
   it('should ignore unknown file', async () => {
     const files = {
       [constants.CLIENTS_DIRECTORY]: {


### PR DESCRIPTION
Story Link: https://grandrounds.atlassian.net/browse/MX-2568

This PR allows the auth0-cli tool to read and sync `clients` from 2 different directory locations. 
The change is pretty much similar to this [PR](https://github.com/auth0/auth0-deploy-cli/pull/220) which added support to read from custom `connections` folder.

### Reason

There are 2 deploy scripts which we use when deploying auth0 settings:

#### bin/deploy

This script is used to deploy all the auth0 settings except sso related `clients` and `connections`. This will deploy the root `clients` like `sso-web`, etc. This works as intended and no change is needed.

#### bin/deploy-sso-connections

This script is used to deploy only the sso related stuff (currently `connections` but we need to add support for `clients`).
It works by cloning the `sso-configuration` repo within `auth0-configuration` and then deploying only the settings present in that cloned folder. In this folder, we'll have another set of `clients` that we want this cli tool to read from and sync with tenant. This path will be specified using the newly added config `ADDITIONAL_CLIENTS_DIRECTORY` 