### PR TITLE
[MX-2613] Fix bug: deploy fails when we only have the ADDITIONAL_CLIENTS_DIRECTORY

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "auth0-deploy-cli",
+  "name": "@ConsultingMD/auth0-deploy-cli",
   "version": "4.2.1",
   "lockfileVersion": 1,
   "requires": true,

--- a/src/context/directory/handlers/clients.js
+++ b/src/context/directory/handlers/clients.js
@@ -9,15 +9,19 @@ function parse(context) {
   var foundFiles = [];
 
   const clientsFolder = path.join(context.filePath, constants.CLIENTS_DIRECTORY);
-  if (!existsMustBeDir(clientsFolder)) return { clients: undefined }; // Skip
-  foundFiles = foundFiles.concat(getFiles(clientsFolder, [ '.json' ]));
+  if (existsMustBeDir(clientsFolder)) {
+    foundFiles = foundFiles.concat(getFiles(clientsFolder, [ '.json' ]));
+  }
 
-  if (context.config.ADDITIONAL_CLIENTS_DIRECTORY) {
-    const additionalClientsFolder = path.join(context.filePath, context.config.ADDITIONAL_CLIENTS_DIRECTORY);
+  if (context.config.AUTH0_ADDITIONAL_CLIENTS_DIRECTORY) {
+    const additionalClientsFolder = path.join(context.filePath, context.config.AUTH0_ADDITIONAL_CLIENTS_DIRECTORY);
+
     if (existsMustBeDir(additionalClientsFolder)) {
       foundFiles = foundFiles.concat(getFiles(additionalClientsFolder, [ '.json' ]));
     }
   }
+
+  if (!foundFiles.length) return { clients: undefined }; // Skip
 
   const clients = foundFiles
     .map((f) => {

--- a/test/context/directory/clients.test.js
+++ b/test/context/directory/clients.test.js
@@ -36,7 +36,7 @@ describe('#directory context clients', () => {
     expect(context.assets.clients).to.deep.equal(target);
   });
 
-  it('should process additional clients directory', async () => {
+  it('should process additional clients directory with clients directory', async () => {
     const additionalClientsDirectory = 'additional-clients';
 
     const files = {
@@ -49,15 +49,39 @@ describe('#directory context clients', () => {
     };
 
     const repoDir = path.join(testDataDir, 'directory', 'clients1');
+    cleanThenMkdir(repoDir);
     createDir(repoDir, files);
 
-    const config = { AUTH0_INPUT_FILE: repoDir, ADDITIONAL_CLIENTS_DIRECTORY: additionalClientsDirectory, AUTH0_KEYWORD_REPLACE_MAPPINGS: { appType: 'spa' } };
+    const config = { AUTH0_INPUT_FILE: repoDir, AUTH0_ADDITIONAL_CLIENTS_DIRECTORY: additionalClientsDirectory, AUTH0_KEYWORD_REPLACE_MAPPINGS: { appType: 'spa' } };
     const context = new Context(config, mockMgmtClient());
     await context.load();
 
     const target = [
       { app_type: 'spa', name: 'defaultClient' },
       { app_type: 'spa', name: 'anotherClient' }
+    ];
+    expect(context.assets.clients).to.deep.equal(target);
+  });
+
+  it('should process additional clients directory w/o clients directory', async () => {
+    const additionalClientsDirectory = 'additional-clients';
+
+    const files = {
+      [additionalClientsDirectory]: {
+        'client.json': '{ "app_type": @@appType@@, "name": "client" }'
+      }
+    };
+
+    const repoDir = path.join(testDataDir, 'directory', 'clients1');
+    cleanThenMkdir(repoDir);
+    createDir(repoDir, files);
+
+    const config = { AUTH0_INPUT_FILE: repoDir, AUTH0_ADDITIONAL_CLIENTS_DIRECTORY: additionalClientsDirectory, AUTH0_KEYWORD_REPLACE_MAPPINGS: { appType: 'spa' } };
+    const context = new Context(config, mockMgmtClient());
+    await context.load();
+
+    const target = [
+      { app_type: 'spa', name: 'client' }
     ];
     expect(context.assets.clients).to.deep.equal(target);
   });


### PR DESCRIPTION
Story Link: https://grandrounds.atlassian.net/browse/MX-2613

### CHANGES

1. When the root `clients` folder is not present, the clients from the additional directory are not being synced. This is needed because we wont have the `clients` folder within the git cloned directory. 

2. Renamed the `ADDITIONAL_CLIENTS_DIRECTORY` to `AUTH0_ADDITIONAL_CLIENTS_DIRECTORY` in regard with the existing naming conventions.